### PR TITLE
migrating webhook to use room_message instead of room_notification

### DIFF
--- a/hipchat-webhook.sh
+++ b/hipchat-webhook.sh
@@ -21,7 +21,7 @@ case "$1" in
 
   --create)
     : ${FORWARD_APP_URL:?"Need to set FORWARD_APP_URL non-empty"}
-    curl -H "Content-Type: application/json" -d "{\"url\":\"$FORWARD_APP_URL\",\"event\": \"room_notification\", \"name\": \"$HIPCHAT_ROOM\" }" \
+    curl -H "Content-Type: application/json" -d "{\"url\":\"$FORWARD_APP_URL\",\"event\": \"room_message\", \"name\": \"$HIPCHAT_ROOM\" }" \
       https://api.hipchat.com/v2/room/$HIPCHAT_ROOM/webhook?auth_token=$HIPCHAT_ADMIN_TOKEN
   ;;
 

--- a/main.go
+++ b/main.go
@@ -23,8 +23,12 @@ type HipChatEventMessage struct {
 	Color         string
 	Id            string
 	MessageFormat string
-	From          string
+	From          HipChatEventMessageFrom
 	Message       string
+}
+
+type HipChatEventMessageFrom struct {
+	Name		string
 }
 
 type HipChatRoom struct {
@@ -53,7 +57,7 @@ func sendToSlack(webhookUrl string, channel string, sourceMessage HipChatEventMe
 
 	message := reformat(sourceMessage.Message)
 
-	slackMessage := SlackMessage{Channel: channel, Username: sourceMessage.From, Text: message}
+	slackMessage := SlackMessage{Channel: channel, Username: sourceMessage.From.Name, Text: message}
 
 	payload, err := json.Marshal(slackMessage)
 	if err != nil {


### PR DESCRIPTION
I don't know if anything has changed with HipChat in the last year, but when I integrated this plugin the Name wasn't come through on the webhook message.  I noticed that the event that was being registered with the HipChat webhook was "room_notification", which wasn't getting fired with a normal message.  So, I switched the webhook event over to "room_message" (which has a different response contract) and then updated the contracts to get the correct Name.  Works correctly now.
